### PR TITLE
Fix missing conflict field in suggestions response.

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -306,8 +306,11 @@ definitions:
         type: string
   MeetingSuggestionsResponse:
     required:
+      - conflict
       - suggestions
     properties:
+      conflict:
+        type: boolean
       suggestions:
         type: array
         items:


### PR DESCRIPTION
Notify API change.

A `conflict` field is added to the response of suggestions endpoint.
